### PR TITLE
Fix field handling in GitHub repo lookup

### DIFF
--- a/lib/hello/github.ex
+++ b/lib/hello/github.ex
@@ -1,5 +1,4 @@
 defmodule Hello.Github do
-
   @base "https://api.github.com/"
   @repo_fragment "repos/"
 
@@ -16,10 +15,17 @@ defmodule Hello.Github do
   """
   def repo_attribute(repo_name \\ "akshar-raaj/mixer", field) do
     full_url = @base <> @repo_fragment <> repo_name
+
     case Req.get(full_url) do
-      {:ok, %{status: 200, body: body}} when is_map(body) -> Map.get(body, field)
-      {:ok, %{status: 404}} -> "Repository not found"
-      {:error, %{reason: reason}} -> "Error. Reason: #{IO.inspect reason}"
+      {:ok, %{status: 200, body: body}} when is_map(body) ->
+        field_key = if is_atom(field), do: Atom.to_string(field), else: field
+        Map.get(body, field_key)
+
+      {:ok, %{status: 404}} ->
+        "Repository not found"
+
+      {:error, %{reason: reason}} ->
+        "Error. Reason: #{IO.inspect(reason)}"
     end
   end
 end


### PR DESCRIPTION
## Summary
- ensure `Hello.Github.repo_attribute/2` works with atom fields by converting them to strings before lookup

## Testing
- `mix test` *(fails: Unchecked dependencies ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf13d7d308333b160a1aada81b1cd