### PR TITLE
Move application env vars to config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,11 @@
 import Config
 
 config :hello,
-  author: "Raaj Akshar",
-  organisation: :ascend_together,
+  author: "Akshar Raaj",
+  organisation: :ascend,
   team: "EPD",
+  location: "Hyderabad",
+  cto: "Prasad Sristi",
   ecto_repos: [Hello.Repo]
 
 config :ex_aws,
@@ -21,6 +23,5 @@ config :hello, Oban,
   engine: Oban.Engines.Basic,
   queues: [default: 10],
   repo: Hello.Repo
-
 
 import_config "#{config_env()}.exs"

--- a/mix.exs
+++ b/mix.exs
@@ -14,13 +14,7 @@ defmodule Hello.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
-      env: [
-        author: "Akshar Raaj",
-        location: "Hyderabad",
-        organisation: :ascend,
-        cto: "Prasad Sristi"
-      ]
+      extra_applications: [:logger]
     ]
   end
 


### PR DESCRIPTION
## Summary
- centralize application env settings in config/config.exs
- remove inline env from mix.exs

## Testing
- `mix format mix.exs config/config.exs`
- `mix test` *(fails: Can't continue due to errors on dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0ed002c8833393b011511a87e040